### PR TITLE
chore: use depot runners

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   lint:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:22
       credentials:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   pin-dependencies-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:22
       credentials:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, edited, synchronize]
 jobs:
   pr-title-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:22
       credentials:


### PR DESCRIPTION
## Summary

- Migrate GitHub Actions from `buildjet-4vcpu-ubuntu-2204` to `depot-ubuntu-22.04-2` to align with dashboard patterns