### PR TITLE
chore: migrate to pnpm 11

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
       - name: Install packages
         run: pnpm install

--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     "@types/react": "19.1.8",
     "wrangler": "4.23.0"
   },
-  "packageManager": "pnpm@10.23.0"
+  "packageManager": "pnpm@11.3.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true
+minimumReleaseAge: 1440

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,3 @@ allowBuilds:
   esbuild: true
   sharp: true
   workerd: true
-minimumReleaseAge: 1440


### PR DESCRIPTION
Migrates the repo's package manager to **pnpm 11**.

- Bumps `packageManager` to `pnpm@11.3.0`
- Adds an `allowBuilds` allowlist in `pnpm-workspace.yaml` so pnpm 11's build-script gate approves the dependencies that need postinstall builds
- Bumps CI Node to 22 (pnpm 11 requires Node >= 22.13)
